### PR TITLE
Add custom robots.txt file

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -4,9 +4,9 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
-      disallow: "/api/",
+      // allow: "/",
+      disallow: "/",
     },
-    sitemap: "https://agentdevai.com/sitemap.xml",
+    // sitemap: "https://agentdevai.com/sitemap.xml",
   }
 }


### PR DESCRIPTION
Implement a custom `robots.txt` configuration to control web crawler access, disallowing all paths while commenting out previous rules.